### PR TITLE
Added support for client results

### DIFF
--- a/signalrkore/build.gradle.kts
+++ b/signalrkore/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
             }
         }
         val jvmMain by getting {

--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HttpHubConnectionBuilder.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HttpHubConnectionBuilder.kt
@@ -12,6 +12,8 @@ class HttpHubConnectionBuilder(private val url: String) {
      */
     var transportEnum: TransportEnum = TransportEnum.All
 
+    internal var transport: Transport? = null
+
     /**
      * The [HttpClient] to be used by the [eu.lepicekmichal.signalrkore.HubConnection]
      */
@@ -72,6 +74,7 @@ class HttpHubConnectionBuilder(private val url: String) {
         if (::protocol.isInitialized) protocol else JsonHubProtocol(logger),
         handshakeResponseTimeout,
         headers.toMap(),
+        transport,
         transportEnum,
         json,
         logger,

--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubMessage.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubMessage.kt
@@ -30,7 +30,7 @@ sealed class HubMessage {
         data class Blocking(
             override val target: String,
             override val arguments: List<JsonElement>,
-            val invocationId: String,
+            val invocationId: String?,
             override val streamIds: List<String>? = null,
         ) :
             Invocation() {
@@ -116,9 +116,10 @@ sealed class HubMessage {
             return when (val type = jsonObject["type"]?.jsonPrimitive?.int) {
                 HubMessageType.INVOCATION.value -> when {
                     jsonObject["streamIds"]?.jsonArray != null -> Invocation.Blocking.serializer()
-                    jsonObject["invocationId"]?.jsonPrimitive?.contentOrNull != null -> Invocation.Streaming.serializer()
+                    jsonObject["invocationId"]?.jsonPrimitive?.contentOrNull != null -> Invocation.Blocking.serializer()
                     else -> Invocation.NonBlocking.serializer()
                 }
+                HubMessageType.STREAM_INVOCATION.value -> Invocation.Streaming.serializer()
                 HubMessageType.PING.value -> Ping.serializer()
                 HubMessageType.CLOSE.value -> Close.serializer()
                 HubMessageType.STREAM_ITEM.value -> StreamItem.serializer()

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/CompletableSubject.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/CompletableSubject.kt
@@ -1,0 +1,26 @@
+package eu.lepicekmichal.signalrkore
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.timeout
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class CompletableSubject {
+    private val stateFlow = MutableStateFlow(false)
+
+    suspend fun waitForCompletion(timeout: Duration = 30.seconds) = withContext(Dispatchers.Default) {
+        stateFlow.filter { it }.timeout(timeout).first()
+    }
+
+    fun reset() {
+        stateFlow.value = false
+    }
+
+    fun complete() {
+        stateFlow.value = true
+    }
+}

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/HubConnectionReturnResultTest.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/HubConnectionReturnResultTest.kt
@@ -1,0 +1,547 @@
+package eu.lepicekmichal.signalrkore
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class HubConnectionReturnResultTest {
+
+    @Test
+    fun `handler with no params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var called = false
+        val job = launch {
+            hubConnection.onWithResult<Int>("inc") {
+                called = true
+                10
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":10}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals(true, called)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with no return value should report an error`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val nonResultCalled = CompletableSubject()
+        val job = launch {
+            hubConnection.on("inc") {
+                nonResultCalled.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"error\":\"Client did not provide a result.\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        nonResultCalled.waitForCompletion()
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `missing handler with return value should report an error`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"error\":\"Client did not provide a result.\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `faulty handler should return an error`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        val job = launch {
+            hubConnection.onWithResult<Int>("inc") {
+                throw RuntimeException("Custom error.")
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"error\":\"Custom error.\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `registering multiple handler should raise an exception`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        val job = launch {
+            hubConnection.onWithResult<String>("inc") { "value" }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        val exception = assertFailsWith<RuntimeException> {
+            hubConnection.onWithResult<String>("inc") { "value2" }
+        }
+        assertEquals("'inc' already has a value returning handler. Multiple return values are not supported.", exception.message)
+
+        job.cancel()
+    }
+
+
+    @Test
+    fun `handler with result should log if server does not expect a return value`() = runTest {
+        val mockTransport = MockTransport()
+        val testLogger = TestLogger()
+        val hubConnection = createHubConnection(mockTransport) {
+            logger = testLogger
+        }
+        val nonResultCalled = CompletableSubject()
+
+        val job = launch {
+            hubConnection.onWithResult<Int>("m") { 42 }
+        }
+
+        val job2 = launch {
+            hubConnection.on("fin") {
+                nonResultCalled.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"m\",\"arguments\":[]}$RECORD_SEPARATOR")
+        // send another invocation message and wait for it to be processed to make sure the first invocation was processed
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"fin\",\"arguments\":[]}$RECORD_SEPARATOR")
+
+        nonResultCalled.waitForCompletion()
+
+        testLogger.assertLogEquals("Result given for 'm' method but server is not expecting a result.")
+
+        job.cancel()
+        job2.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with one param should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int>("inc") {
+                calledWith = it
+                10
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\"]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":10}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with two params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, String>("inc") { p1, p2 ->
+                calledWith = p1
+                calledWith2 = p2
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\", 13]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with three params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, String>("inc") { p1, p2, p3 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3]]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with four params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, Boolean, String>("inc") { p1, p2, p3, p4 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with five params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, Boolean, String, String>("inc") { p1, p2, p3, p4, p5 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\"]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with six params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, Boolean, String, Double, String>("inc") { p1, p2, p3, p4, p5, p6 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with seven params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        var calledWith7: String? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, Boolean, String, Double, String, String>("inc") { p1, p2, p3, p4, p5, p6, p7 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                calledWith7 = p7
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5,\"h\"]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+        assertEquals("h", calledWith7)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with eight params should return a value`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        var calledWith7: String? = null
+        var calledWith8: Int? = null
+        val job = launch {
+            hubConnection.onWithResult<String, Int, IntArray, Boolean, String, Double, String, Int, String>("inc") { p1, p2, p3, p4, p5, p6, p7, p8 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                calledWith7 = p7
+                calledWith8 = p8
+                "bob"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5,\"h\",33]}$RECORD_SEPARATOR")
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+
+        assertEquals(expected, response)
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+        assertEquals("h", calledWith7)
+        assertEquals(33, calledWith8)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with return value should not block other handlers`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val resultCalled = CompletableSubject()
+        val nonResultCalled = CompletableSubject()
+        val completeResult = CompletableSubject()
+
+        val job = launch {
+            hubConnection.onWithResult<String>("inc") {
+                resultCalled.complete()
+                completeResult.waitForCompletion()
+                "bob"
+            }
+        }
+
+        val job2 = launch {
+            hubConnection.on("inc2") {
+                nonResultCalled.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"1\"]}$RECORD_SEPARATOR")
+        resultCalled.waitForCompletion()
+
+        // Send an non-result invocation and make sure it's processed even with a blocking result invocation
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc2\",\"arguments\":[\"1\"]}$RECORD_SEPARATOR")
+        nonResultCalled.waitForCompletion()
+
+        completeResult.complete()
+
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"result\":\"bob\"}$RECORD_SEPARATOR"
+        assertEquals(expected, response)
+
+        job.cancel()
+        job2.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler should return an error if cannot parse argument`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+
+        val job = launch {
+            hubConnection.onWithResult<Int, String>("inc") { "bob" }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        val sentMessage = mockTransport.nextSentMessage
+        mockTransport.receiveMessage("{\"type\":1,\"invocationId\":\"1\",\"target\":\"inc\",\"arguments\":[\"not int\"]}$RECORD_SEPARATOR")
+
+        val response = sentMessage.waitForResult()
+        val expected = "{\"type\":3,\"invocationId\":\"1\",\"error\":\"Failed to parse literal as 'int' value\\nJSON input: \\\"not int\\\"\"}$RECORD_SEPARATOR"
+        assertEquals(expected, response)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    private fun createHubConnection(customTransport: Transport, block: HttpHubConnectionBuilder.() -> Unit = {}): HubConnection {
+        val builder = HttpHubConnectionBuilder("http://example.com").apply {
+            transport = customTransport
+            skipNegotiate = true
+            transportEnum = TransportEnum.WebSockets
+        }
+        builder.apply(block)
+
+        return builder.build()
+    }
+}

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/HubConnectionTest.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/HubConnectionTest.kt
@@ -1,0 +1,408 @@
+package eu.lepicekmichal.signalrkore
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class HubConnectionTest {
+
+    @Test
+    fun `registering multiple handlers with parameter should all be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+        val value = SingleSubject<Double>()
+
+        val action: (Double) -> Unit = {
+            launch {
+                value.setResult((value.result ?: 0.0) + it)
+                if (value.result == 24.0) {
+                    completable.complete()
+                }
+            }
+        }
+
+        val job = launch { hubConnection.on<Double>("add", action) }
+        val job2 = launch { hubConnection.on<Double>("add", action) }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"add\",\"arguments\":[12]}$RECORD_SEPARATOR")
+
+        // Confirming that our handler was called and the correct message was passed in.
+        completable.waitForCompletion()
+        assertEquals(24.0, value.result)
+
+        job.cancel()
+        job2.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler without param should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        val job = launch {
+            hubConnection.on("inc") {
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with one param should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        val job = launch {
+            hubConnection.on<String>("inc") {
+                calledWith = it
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\"]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with two params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        val job = launch {
+            hubConnection.on<String, Int>("inc") { p1, p2 ->
+                calledWith = p1
+                calledWith2 = p2
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with three params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray>("inc") { p1, p2, p3 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3]]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with four params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray, Boolean>("inc") { p1, p2, p3, p4 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with five params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray, Boolean, String>("inc") { p1, p2, p3, p4, p5 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\"]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with six params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray, Boolean, String, Double>("inc") { p1, p2, p3, p4, p5, p6 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with seven params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        var calledWith7: String? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray, Boolean, String, Double, String>("inc") { p1, p2, p3, p4, p5, p6, p7 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                calledWith7 = p7
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5,\"h\"]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+        assertEquals("h", calledWith7)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `handler with eight params should be triggered`() = runTest {
+        val mockTransport = MockTransport()
+        val hubConnection = createHubConnection(mockTransport)
+        val completable = CompletableSubject()
+
+        var calledWith: String? = null
+        var calledWith2: Int? = null
+        var calledWith3: IntArray? = null
+        var calledWith4: Boolean? = null
+        var calledWith5: String? = null
+        var calledWith6: Double? = null
+        var calledWith7: String? = null
+        var calledWith8: Int? = null
+        val job = launch {
+            hubConnection.on<String, Int, IntArray, Boolean, String, Double, String, Int>("inc") { p1, p2, p3, p4, p5, p6, p7, p8 ->
+                calledWith = p1
+                calledWith2 = p2
+                calledWith3 = p3
+                calledWith4 = p4
+                calledWith5 = p5
+                calledWith6 = p6
+                calledWith7 = p7
+                calledWith8 = p8
+                completable.complete()
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"1\",13,[1,2,3],true,\"t\",1.5,\"h\",33]}$RECORD_SEPARATOR")
+        completable.waitForCompletion()
+
+        assertEquals("1", calledWith)
+        assertEquals(13, calledWith2)
+        assertContentEquals(intArrayOf(1, 2, 3), calledWith3)
+        assertEquals(true, calledWith4)
+        assertEquals("t", calledWith5)
+        assertEquals(1.5, calledWith6)
+        assertEquals("h", calledWith7)
+        assertEquals(33, calledWith8)
+
+        job.cancel()
+        hubConnection.stop()
+    }
+
+    @Test
+    fun `throwing from one handler should not stop triggering other handlers`() = runTest {
+        val mockTransport = MockTransport()
+        val testLogger = TestLogger()
+        val hubConnection = createHubConnection(mockTransport) {
+            logger = testLogger
+        }
+        val value1 = SingleSubject<String>()
+        val value2 = SingleSubject<String>()
+
+        val job = launch {
+            hubConnection.on<String>("inc") { p1 ->
+                value1.setResult(p1)
+                throw RuntimeException("throw from on handler")
+            }
+        }
+
+        val job2 = launch {
+            hubConnection.on<String>("inc") { p1 ->
+                value2.setResult(p1)
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        hubConnection.start()
+        mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"Hello World\"]}$RECORD_SEPARATOR")
+
+        // Confirming that our handler was called and the correct message was passed in.
+        assertEquals("Hello World", value1.waitForResult())
+        assertEquals("Hello World", value2.waitForResult())
+
+        val log = testLogger.assertLogEquals("Invoking client side method 'inc' failed: java.lang.RuntimeException: throw from on handler")
+        assertEquals(Logger.Level.ERROR, log.level)
+
+        job.cancel()
+        job2.cancel()
+        hubConnection.stop()
+    }
+
+    private fun createHubConnection(customTransport: Transport, block: HttpHubConnectionBuilder.() -> Unit = {}): HubConnection {
+        val builder = HttpHubConnectionBuilder("http://example.com").apply {
+            transport = customTransport
+            skipNegotiate = true
+            transportEnum = TransportEnum.WebSockets
+        }
+        builder.apply(block)
+
+        return builder.build()
+    }
+}

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/MockTransport.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/MockTransport.kt
@@ -1,0 +1,60 @@
+package eu.lepicekmichal.signalrkore
+
+import io.ktor.utils.io.core.toByteArray
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class MockTransport(
+    private val ignorePings: Boolean = true,
+    private val autoHandshake: Boolean = true
+) : Transport {
+
+    private val receivedMessages: MutableSharedFlow<String> = MutableSharedFlow()
+
+    var nextSentMessage: SingleSubject<String> = SingleSubject()
+        private set
+
+    lateinit var url: String
+        private set
+
+    override suspend fun start(url: String) {
+        this.url = url
+        if (autoHandshake) {
+            CoroutineScope(Dispatchers.IO).launch {
+                receivedMessages.subscriptionCount.filter { it > 0 }.first()
+                receivedMessages.emit("{}$RECORD_SEPARATOR")
+            }
+        }
+    }
+
+    override suspend fun send(message: ByteArray) {
+        if (!ignorePings || !isPing(message)) {
+            nextSentMessage.setResult(io.ktor.utils.io.core.String(message))
+            nextSentMessage = SingleSubject()
+        }
+    }
+
+    override fun receive(): Flow<ByteArray> = receivedMessages.map { it.toByteArray() }
+
+    override suspend fun stop() { }
+
+    suspend fun receiveMessage(message: String, waitForSubscriber: Boolean = true) {
+        if (waitForSubscriber) {
+            receivedMessages.subscriptionCount.filter { it > 0 }.first()
+        }
+
+        receivedMessages.emit(message)
+    }
+
+    private fun isPing(message: ByteArray): Boolean {
+        return io.ktor.utils.io.core.String(message) == "{\"type\":6}$RECORD_SEPARATOR" ||
+                (message[0].toInt() == 2 && message[1].toInt() == -111 && message[2].toInt() == 6)
+    }
+}

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/SingleSubject.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/SingleSubject.kt
@@ -1,0 +1,29 @@
+package eu.lepicekmichal.signalrkore
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.timeout
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class SingleSubject<T> {
+    private val stateFlow = MutableStateFlow<T?>(null)
+
+    val result get() = stateFlow.value
+
+    suspend fun waitForResult(timeout: Duration = 30.seconds) : T =
+        withContext(Dispatchers.Default) {
+            stateFlow.filter { it != null }.timeout(timeout).first() as T
+        }
+
+    fun reset() {
+        stateFlow.value = null
+    }
+
+    fun setResult(value: T) {
+        stateFlow.value = value
+    }
+}

--- a/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/TestLogger.kt
+++ b/signalrkore/src/commonTest/kotlin/eu/lepicekmichal/signalrkore/TestLogger.kt
@@ -1,0 +1,30 @@
+package eu.lepicekmichal.signalrkore
+
+import kotlin.test.assertNotNull
+
+data class LogEvent(val level: Logger.Level, val message: String)
+
+class TestLogger : Logger {
+
+    private val logs: MutableList<LogEvent> = mutableListOf()
+
+    override fun log(level: Logger.Level, message: String) {
+        logs.add(LogEvent(level, message))
+    }
+
+    fun assertLogEquals(message: String): LogEvent {
+        val log = logs.firstOrNull { it.message == message }
+
+        assertNotNull(log, "Log message '$message' not found")
+
+        return log
+    }
+
+    fun assertLogContains(message: String): LogEvent {
+        val log = logs.firstOrNull { it.message.contains(message) }
+
+        assertNotNull(log, "Log message containing '$message' not found")
+
+        return log
+    }
+}


### PR DESCRIPTION
Fixes #1 

This PR contains the following:
- Ported `onWithResult` method from the Java library including tests
- Added inline functions for `on` and `onWithResult` methods with a callback for simpler usage (e.g. `on<String>() { ... }`)
- Added `on` overload with a callback and no parameters
- Added error handling for `on` functions with a callback
- Ported tests for `on` functions from the Java library