### PR TITLE
Fix crash when sending a hub message after connection closure

### DIFF
--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubConnection.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubConnection.kt
@@ -363,15 +363,19 @@ class HubConnection private constructor(
 
     override fun sendHubMessage(message: HubMessage) {
         if (connectionState.value != HubConnectionState.CONNECTED) {
-            logger.log(Logger.Severity.ERROR, "Trying to send and message while the connection is not active. ($message)", null)
+            logger.log(Logger.Severity.ERROR, "Trying to send a message while the connection is not active. ($message)", null)
             return
         }
 
         val serializedMessage: ByteArray = protocol.writeMessage(message)
         scope.launch {
-            if (::transport.isInitialized) transport.send(serializedMessage)
-            logger.log(Logger.Severity.INFO, "Sent hub data: $message", null)
-            resetKeepAlive()
+            try {
+                if (::transport.isInitialized) transport.send(serializedMessage)
+                logger.log(Logger.Severity.INFO, "Sent hub data: $message", null)
+                resetKeepAlive()
+            } catch (e: Exception) {
+                logger.log(Logger.Severity.ERROR, "Failed to send hub data: $message", e)
+            }
         }
     }
 

--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/transports/WebSocketTransport.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/transports/WebSocketTransport.kt
@@ -49,7 +49,11 @@ internal class WebSocketTransport(
     }
 
     override suspend fun send(message: ByteArray) {
-        session?.send(message) ?: throw IllegalStateException("WebSocket connection has not been started")
+        try {
+            session?.send(message) ?: throw IllegalStateException("WebSocket connection has not been started")
+        } catch (e: EOFException) {
+            throw IllegalStateException("WebSocket connection has been closed", e)
+        }
     }
 
     override fun receive(): Flow<ByteArray> = session?.incoming


### PR DESCRIPTION
Stopping the server-side in .NET Aspire often crashes the Android application due to an unhandled exception in the SignalKore library when WebSockets are used as the transport. Here is the Android exception that happens when stopping the server-side:
```
AndroidRuntime          com.abrantix.apa.android.phone       E  FATAL EXCEPTION: DefaultDispatcher-worker-7
Process: com.abrantix.apa.android.phone, PID: 6640
java.io.EOFException
	at okio.RealBufferedSource.require(RealBufferedSource.kt:204)
	at okio.RealBufferedSource.readByte(RealBufferedSource.kt:214)
	at okhttp3.internal.ws.WebSocketReader.readHeader(WebSocketReader.kt:119)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.kt:102)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.kt:293)
	at okhttp3.internal.ws.RealWebSocket$connect$1.onResponse(RealWebSocket.kt:195)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@582c6ae, Dispatchers.IO]
Process                 com.abrantix.apa.android.phone       I  Sending signal. PID: 6640 SIG: 9
```
The `if` statement in the `sendHubMessage` does not handle the case when the connection is closed during `transport.send` call. Wrapping the sending logic inside a try/catch block does prevent the application from crashing.
