### PR TITLE
Fixed transports using old token on reconnect with accessTokenProvider

### DIFF
--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HttpHubConnectionBuilder.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HttpHubConnectionBuilder.kt
@@ -70,7 +70,6 @@ class HttpHubConnectionBuilder(private val url: String) {
         headers = headers,
         accessTokenProvider = accessTokenProvider,
         transportEnum = transportEnum,
-        transport = null,
         json = json,
         logger = logger,
     )


### PR DESCRIPTION
When using `accessTokenProvider`, the access token is not updated on reconnect because the transport created during the initial connection attempt is never refreshed with the new token.

How to reproduce the issue:
1. Connect to the server using a valid access token
2. Wait for the access token to expire
3. Restart the server so the client triggers a reconnect
4. The reconnect fails because the new token is not passed to the previously initialized transport

This PR resolves the issue by recreating the transport after each negotiation. Since the selected transport may change on reconnect, reinitializing it ensures that the connection uses the newly negotiated transport and correctly applies the updated access token.