### PR TITLE
Improve error handling for WebSocket broken pipe and cancelled hub invocations

### DIFF
--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubCommunicationLink.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubCommunicationLink.kt
@@ -41,8 +41,16 @@ abstract class HubCommunicationLink(private val json: Json) : HubCommunication()
     protected abstract fun connectedCheck(method: String)
 
     private fun complete(message: HubMessage.Completion) {
-        connectedCheck("complete")
-        sendHubMessage(message)
+        try {
+            connectedCheck("complete")
+            sendHubMessage(message)
+        } catch (ex: Exception) {
+            logger.log(
+                severity = Logger.Severity.ERROR,
+                message = "Sending completion message has thrown an exception",
+                cause = ex,
+            )
+        }
     }
 
     final override fun send(method: String, args: List<JsonElement>, streams: List<Flow<JsonElement>>) {

--- a/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubConnection.kt
+++ b/signalrkore/src/commonMain/kotlin/eu/lepicekmichal/signalrkore/HubConnection.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.net.SocketException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -425,6 +426,10 @@ class HubConnection private constructor(
                 resetKeepAlive()
             } catch (e: Exception) {
                 logger.log(Logger.Severity.ERROR, "Failed to send hub data: $message", e)
+                if (e is SocketException) {
+                    if (automaticReconnect !is AutomaticReconnect.Inactive) reconnect(e.message)
+                    else stop(e.message)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR improves error handling for two scenarios that are currently causing either:
- the application to crash, or
- the client connection to become unusable without reconnecting


1. Broken pipe when sending hub data

We observed the following exception multiple times in the field (I do not have an explanation why this happens):
```
Failed to send hub data: eu.lepicekmichal.signalrkore.HubMessage$Ping@fcba8c4
java.net.SocketException: Broken pipe
	at java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:117)
	at java.net.SocketOutputStream.write(SocketOutputStream.java:161)
	at com.android.org.conscrypt.ConscryptEngineSocket$SSLOutputStream.writeToSocket(ConscryptEngineSocket.java:724)
	at com.android.org.conscrypt.ConscryptEngineSocket$SSLOutputStream.writeInternal(ConscryptEngineSocket.java:698)
	at com.android.org.conscrypt.ConscryptEngineSocket$SSLOutputStream.write(ConscryptEngineSocket.java:661)
	at okio.internal.DefaultSocket$SocketSink.write(DefaultSocket.kt:62)
	at okio.RealBufferedSink.flush(RealBufferedSink.kt:268)
	at okio.ForwardingSink.flush(ForwardingSink.kt:32)
	at okhttp3.internal.connection.Exchange$RequestBodySink.flush(Exchange.kt:268)
	at okio.RealBufferedSink.flush(RealBufferedSink.kt:270)
	at okhttp3.internal.ws.WebSocketWriter.writeMessageFrame(WebSocketWriter.kt:207)
	at okhttp3.internal.ws.RealWebSocket.writeOneFrame$okhttp(RealWebSocket.kt:565)
	at okhttp3.internal.ws.RealWebSocket$WriterTask.runOnce(RealWebSocket.kt:669)
	at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:81)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
```
When this occurs, the client is no longer able to send data to the server, although it can still receive messages. In this case, the only solution is to reconnect, which is what has been implemented in this PR.

2. Crash when server cancels hub method invocation

If the server cancels a hub method invocation before the client completes it, the client throws the following exception:
```
java.lang.RuntimeException: The 'complete' method cannot be called if the connection is not active.
	at eu.lepicekmichal.signalrkore.HubConnection.connectedCheck(HubConnection.kt:471)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink.complete(HubCommunicationLink.kt:45)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink.access$complete(HubCommunicationLink.kt:23)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink$handleIncomingInvocation$1.invokeSuspend(HubCommunicationLink.kt:263)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink$handleIncomingInvocation$1.invoke(Unknown Source:8)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink$handleIncomingInvocation$1.invoke(Unknown Source:4)
	at eu.lepicekmichal.signalrkore.FlowKt$collectInScope$1$1.emit(Flow.kt:24)
	at kotlinx.coroutines.flow.FlowKt__TransformKt$onEach$$inlined$unsafeTransform$1$2.emit(Emitters.kt:51)
	at eu.lepicekmichal.signalrkore.HubCommunicationLink$on$$inlined$filter$1$2.emit(Emitters.kt:50)
	at kotlinx.coroutines.flow.SharedFlowImpl.collect$suspendImpl(SharedFlow.kt:397)
	at kotlinx.coroutines.flow.SharedFlowImpl$collect$1.invokeSuspend(Unknown Source:15)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
```
This currently causes the application to crash because the exception is not caught. This PR wraps the complete call in a try/catch block to handle this scenario gracefully and prevent the crash.